### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heroku Multi Procfile buildpack
+# Heroku Monorepo Buildpack
 
 Imagine you have a single code base, which has a few different applications within it... or at least the ability to run a few different applications. Or, maybe you're Google with your mono repo?
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Enter the Monorepo buildpack, which is a copy of [heroku-buildpack-multi-procfil
    `heroku buildpacks:add -a <app> https://github.com/lstoll/heroku-buildpack-monorepo`
 4. For each app, `git push git@heroku.com:<app> master`
 
+Note: If you already have other buildpacks defined, you'll need to make sure that the heroku-buildpack-monorepo buildpack is defined first. You can do this by adding `-i 1` to the `heroku buildpacks:add` command.
+
 # Authors
 
 Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com> and now Lincoln Stoll <lstoll@heroku.com>

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Ensure wildcards in globs match dotfiles too.
+shopt -s dotglob
+
 indent() {
     sed -u 's/^/      /'
 }
@@ -16,8 +20,8 @@ APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    rm -rf "${BUILD_DIR}" &&
-    mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
+    rm -rf "${BUILD_DIR}"/* &&
+    mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}"
 )
 
 if [ $? -ne 0 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -1,28 +1,27 @@
 #!/usr/bin/env bash
-
 indent() {
     sed -u 's/^/      /'
 }
 
-BUILD_DIR=$1
-CACHE_DIR=$2
-ENV_DIR=$3
+BUILD_DIR="$1"
+CACHE_DIR="$2"
+ENV_DIR="$3"
+STAGE="$(mktemp -d)"
 
-if [ ! -f ${ENV_DIR}/APP_BASE ]; then
+if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
     echo "APP_BASE was not set. Aborting" | indent
+    exit 1
 fi
-APP_BASE=$(cat ${ENV_DIR}/APP_BASE)
+APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
-    stage=`mktemp -d` &&
-    mv ${BUILD_DIR}/${APP_BASE} ${stage} &&
-    shopt -s dotglob nullglob &&
-    rm -rf ${BUILD_DIR}/* &&
-    mv ${stage}/${APP_BASE}/* ${BUILD_DIR}
+    mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
+    rm -rf "${BUILD_DIR}" &&
+    mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
 )
 
-if ! [ $? ]; then
-    echo "FAILED to copy a Procfile" | indent
+if [ $? -ne 0 ]; then
+    echo "FAILED to copy directory into place" | indent
     exit 1
 fi
 


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack fail with errors like:

```
remote: -----> Monorepo app detected
remote: rm: cannot remove '/app': Read-only file system
remote:       FAILED to copy directory into place
remote:  !     Push rejected, failed to compile Monorepo app.
```

A fix for this compatibility issue has been merged into the upstream repository from which this one is forked:
lstoll/heroku-buildpack-monorepo/pull/13

This PR merges the changes from the upstream repository (which include that fix) back to this fork, so as to avoid any disruption to your builds in the future.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
lstoll/heroku-buildpack-monorepo/issues/12

I'm also happy to answer any questions you may have via discussion on this PR :-)